### PR TITLE
feat: Implement dark theme mode

### DIFF
--- a/src/Components/AddMatch.tsx
+++ b/src/Components/AddMatch.tsx
@@ -110,7 +110,7 @@ function AddMatch() {
   };
   return (
     <>
-      <div style={{border: "2px solid black", marginTop: "20%", width: "100%"}}>
+      <div style={{border: "2px solid var(--input-border-color)", marginTop: "20%", width: "100%"}}> {/* Updated border */}
         {/* <Protected /> */}
         <Navbar />
         <Container component="main" maxWidth="xs">
@@ -140,7 +140,16 @@ function AddMatch() {
                 onChange={handleChange}
                 autoFocus
                 data-testid="matchName"
-                style={{ backgroundColor: "#cbcecf" }}
+                sx={{ // Updated
+                  backgroundColor: 'var(--input-bg)',
+                  '.MuiOutlinedInput-root': {
+                    '& fieldset': { borderColor: 'var(--input-border-color)' },
+                    '&:hover fieldset': { borderColor: 'var(--link-color)' },
+                    '&.Mui-focused fieldset': { borderColor: 'var(--link-color)' },
+                  },
+                  '.MuiInputLabel-root': { color: 'var(--placeholder-text-color)' },
+                  input: { color: 'var(--input-text-color)' }
+                }}
               />
               <TextField
                 margin="normal"
@@ -152,15 +161,31 @@ function AddMatch() {
                 type="string"
                 id="totalAudience"
                 onChange={handleChange}
-                style={{ backgroundColor: "#cbcecf" }}
+                sx={{ // Updated
+                  backgroundColor: 'var(--input-bg)',
+                  '.MuiOutlinedInput-root': {
+                    '& fieldset': { borderColor: 'var(--input-border-color)' },
+                    '&:hover fieldset': { borderColor: 'var(--link-color)' },
+                    '&.Mui-focused fieldset': { borderColor: 'var(--link-color)' },
+                  },
+                  '.MuiInputLabel-root': { color: 'var(--placeholder-text-color)' },
+                  input: { color: 'var(--input-text-color)' }
+                }}
               />
 
               <FormControl
-                sx={{
+                sx={{ // Updated
                   mt: 1,
                   minWidth: "100%",
                   maxWidth: "100%",
-                  backgroundColor: "#cbcecf",
+                  backgroundColor: 'var(--input-bg)',
+                  '.MuiOutlinedInput-root': {
+                    '& fieldset': { borderColor: 'var(--input-border-color)' },
+                    '&:hover fieldset': { borderColor: 'var(--link-color)' },
+                    '&.Mui-focused fieldset': { borderColor: 'var(--link-color)' },
+                  },
+                  '.MuiInputLabel-root': { color: 'var(--placeholder-text-color)' },
+                  '.MuiSelect-select': { color: 'var(--input-text-color)' }
                 }}
               >
                 <InputLabel id="demo-simple-select-helper-label" required>
@@ -194,7 +219,13 @@ function AddMatch() {
                 type="submit"
                 fullWidth
                 variant="contained"
-                sx={{ mt: 3, mb: 2 }}
+                  sx={{ // Updated
+                    mt: 3, 
+                    mb: 2,
+                    backgroundColor: 'var(--button-bg)', 
+                    color: 'var(--button-text)',
+                    '&:hover': { backgroundColor: 'var(--button-hover-bg)' } 
+                  }}
                 data-testid="addmatchbutton"
               >
                 Add Match

--- a/src/Components/AddPlayer.tsx
+++ b/src/Components/AddPlayer.tsx
@@ -44,7 +44,7 @@ function AddPlayer() {
   };
 
   return (
-    <div style={{ border: "3px solid black", marginTop: "20%", width: "100%" }}>
+    <div style={{ border: "3px solid var(--input-border-color)", marginTop: "20%", width: "100%" }}> {/* Updated border */}
       <Navbar />
       <Container component="main" maxWidth="xs">
         <CssBaseline />
@@ -68,7 +68,16 @@ function AddPlayer() {
           margin="normal"
           required
           fullWidth
-          style={{ backgroundColor: "#cbcecf" }}
+          sx={{ // Updated
+            backgroundColor: 'var(--input-bg)',
+            '.MuiOutlinedInput-root': {
+              '& fieldset': { borderColor: 'var(--input-border-color)' },
+              '&:hover fieldset': { borderColor: 'var(--link-color)' },
+              '&.Mui-focused fieldset': { borderColor: 'var(--link-color)' },
+            },
+            '.MuiInputLabel-root': { color: 'var(--placeholder-text-color)' },
+            input: { color: 'var(--input-text-color)' }
+          }}
           label="First Name"
           placeholder="First Name"
           onChange={(e) => {
@@ -87,7 +96,16 @@ function AddPlayer() {
           onChange={(e) => {
             setLastName(e.target.value);
           }}
-          style={{ backgroundColor: "#cbcecf" }}
+          sx={{ // Updated
+            backgroundColor: 'var(--input-bg)',
+            '.MuiOutlinedInput-root': {
+              '& fieldset': { borderColor: 'var(--input-border-color)' },
+              '&:hover fieldset': { borderColor: 'var(--link-color)' },
+              '&.Mui-focused fieldset': { borderColor: 'var(--link-color)' },
+            },
+            '.MuiInputLabel-root': { color: 'var(--placeholder-text-color)' },
+            input: { color: 'var(--input-text-color)' }
+          }}
         ></TextField>
 
         <TextField
@@ -95,7 +113,16 @@ function AddPlayer() {
           required
           fullWidth
           label="Age"
-          style={{ backgroundColor: "#cbcecf" }}
+          sx={{ // Updated
+            backgroundColor: 'var(--input-bg)',
+            '.MuiOutlinedInput-root': {
+              '& fieldset': { borderColor: 'var(--input-border-color)' },
+              '&:hover fieldset': { borderColor: 'var(--link-color)' },
+              '&.Mui-focused fieldset': { borderColor: 'var(--link-color)' },
+            },
+            '.MuiInputLabel-root': { color: 'var(--placeholder-text-color)' },
+            input: { color: 'var(--input-text-color)' }
+          }}
           type="text"
           placeholder="Age"
           onChange={(e) => {
@@ -107,7 +134,13 @@ function AddPlayer() {
           type="submit"
           fullWidth
           variant="contained"
-          sx={{ mt: 3, mb: 2 }}
+          sx={{ // Updated
+            mt: 3, 
+            mb: 2,
+            backgroundColor: 'var(--button-bg)', 
+            color: 'var(--button-text)',
+            '&:hover': { backgroundColor: 'var(--button-hover-bg)' } 
+          }}
           data-testid="addplayerbutton"
           onClick={CreateNewPlayer}
         >

--- a/src/Components/DeleteDialog.tsx
+++ b/src/Components/DeleteDialog.tsx
@@ -80,7 +80,16 @@ export default function AlertDialogSlide({
 
   return (
     <div >
-      <Button variant="contained" onClick={handleClickOpen} data-testid="delete"  >
+      <Button 
+        variant="contained" 
+        onClick={handleClickOpen} 
+        data-testid="delete"
+        sx={{ // Updated
+          backgroundColor: 'var(--button-bg)', 
+          color: 'var(--button-text)',
+          '&:hover': { backgroundColor: 'var(--button-hover-bg)' } 
+        }}
+      >
         Delete
       </Button>
       <Dialog
@@ -89,18 +98,40 @@ export default function AlertDialogSlide({
         keepMounted
         onClose={handleClose}
         aria-describedby="alert-dialog-slide-description"
+        PaperProps={{ // Updated
+          sx: { 
+            backgroundColor: 'var(--card-bg)', 
+            color: 'var(--text-color)' 
+          } 
+        }}
       >
-        <DialogTitle>{"Delete item"}</DialogTitle>
+        <DialogTitle sx={{ color: 'var(--text-color)' }}> {/* Updated */}
+          {"Delete item"}
+        </DialogTitle>
         <DialogContent>
-          <DialogContentText id="alert-dialog-slide-description">
+          <DialogContentText id="alert-dialog-slide-description" sx={{ color: 'var(--text-color)' }}> {/* Updated */}
             Are you sure ?
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose} data-testid="disagreebutton">
+          <Button 
+            onClick={handleClose} 
+            data-testid="disagreebutton"
+            sx={{ // Updated
+              color: 'var(--text-color)', 
+              '&:hover': { backgroundColor: `rgba(${'var(--text-color-rgb)'}, 0.08)` } 
+            }}
+          >
             Disagree
           </Button>
-          <Button onClick={handleDelete} data-testid="agreebutton">
+          <Button 
+            onClick={handleDelete} 
+            data-testid="agreebutton"
+            sx={{ // Updated
+              color: 'var(--link-color)', 
+              '&:hover': { backgroundColor: `rgba(${'var(--link-color-rgb)'}, 0.08)` } 
+            }}
+          >
             Agree
           </Button>
         </DialogActions>

--- a/src/Components/Login.tsx
+++ b/src/Components/Login.tsx
@@ -50,17 +50,18 @@ function Login() {
   return (
     <div style={{ justifyContent: "center" }}>
       <nav
-        className="bg-dark navbar-dark navbar"
+        className="bg-dark navbar-dark navbar" // These classes are now themed by src/theme.css
         style={{ marginTop: "200px" }}
       >
-        <div className="row col-12 d-flex justify-content-center text-white">
+        <div className="row col-12 d-flex justify-content-center text-white"> {/* text-white is themed */}
           <h3 data-testid="login">Login</h3>
         </div>
       </nav>
       <div
-        className="form"
+        className="form" // We can add a class like 'themed-card' if we define it in theme.css
         style={{
-          backgroundColor: "#ffffff",
+          backgroundColor: "var(--card-bg)", // Use CSS variable
+          boxShadow: "var(--card-box-shadow)", // Use CSS variable
           borderRadius: "5px",
           width: "550px",
           margin: "20px auto",
@@ -73,15 +74,15 @@ function Login() {
         >
           <div className="username" data-testid="first name">
             <label
-              className="form__label"
+              className="form__label" // Style this class globally or ensure text color is inherited
               htmlFor="firstName"
-              style={{ width: "40%", padding: "5px" }}
+              style={{ width: "40%", padding: "5px", color: "var(--text-color)" }} // Added text color
               data-testid="firstnamelabel"
             >
               First Name
             </label>
             <input
-              className="form__input"
+              className="form__input" // This class is styled in theme.css for dark mode
               type="text"
               // value="Name"
               id="firstName"
@@ -89,34 +90,37 @@ function Login() {
               onChange={(e) => {
                 setUserName(e.target.value);
               }}
+              // Inline styles for inputs are removed if covered by .form__input in theme.css
             />
           </div>
           <div className="password" data-testid="password">
             <label
-              className="form__label"
+              className="form__label" // Style this class globally or ensure text color is inherited
               htmlFor="password"
-              style={{ width: "40%", padding: "5px" }}
+              style={{ width: "40%", padding: "5px", color: "var(--text-color)" }} // Added text color
               data-testid="passwordlabel"
             >
               Password{" "}
             </label>
             <input
-              className="form__input"
+              className="form__input" // This class is styled in theme.css for dark mode
               type="password"
               id="password"
               placeholder="Password"
               onChange={(e) => {
                 setPassword(e.target.value);
               }}
+              // Inline styles for inputs are removed if covered by .form__input in theme.css
             />
           </div>
         </div>
         <div className="footer" style={{ textAlign: "center" }}>
           <button
-            className="btn"
+            className="btn" // This class is styled in theme.css for dark mode
             data-testid="Login-button"
             type="submit"
             onClick={login}
+            // Inline style for button color/bg removed, rely on .btn styles from theme.css
           >
             Login
           </button>

--- a/src/Components/Match.tsx
+++ b/src/Components/Match.tsx
@@ -117,7 +117,7 @@ export function Match(): JSX.Element {
                           sx={{ maxWidth: 255 }}
                           style={{
                             marginTop: "10",
-                            backgroundColor: "rgb(195 186 169)",
+                            backgroundColor: "var(--card-bg-alt)", // Updated
                             width: "400px",
                           }}
                           data-testid="card-id"
@@ -168,8 +168,12 @@ export function Match(): JSX.Element {
               marginTop: "5%",
               marginBottom: "10%",
               marginLeft: "45%",
-              color: "#9d7506",
+              color: "var(--button-text)", // Updated
+              backgroundColor: "var(--button-bg)", // Updated
+              border: "1px solid var(--button-border-color)", // Added for consistency
               width: "120px",
+              padding: "8px 16px", // Added for better appearance
+              borderRadius: "4px", // Added for better appearance
             }}
           >
             Add Match

--- a/src/Components/NavBar.test.tsx
+++ b/src/Components/NavBar.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from './NavBar';
+import { ThemeProvider, ThemeContext, ThemeContextType } from '../Context/ThemeContext';
+
+// Mock localStorage for ThemeProvider
+const localStorageMock = (() => {
+  let store: { [key: string]: string } = {};
+  return {
+    getItem: jest.fn(key => store[key] || null),
+    setItem: jest.fn((key, value) => {
+      store[key] = value.toString();
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+    removeItem: jest.fn(key => {
+      delete store[key];
+    }),
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+
+describe('Navbar Theme Toggle', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    localStorageMock.setItem.mockClear();
+    localStorageMock.getItem.mockClear();
+    // Ensure body class is reset for each test if ThemeProvider side effects are involved
+    document.body.classList.remove('dark-theme');
+  });
+
+  test('renders the theme toggle button', () => {
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <Navbar />
+        </ThemeProvider>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('theme-toggle-button')).toBeInTheDocument();
+  });
+
+  test('clicking the theme toggle button calls toggleTheme from context', () => {
+    const mockToggleTheme = jest.fn();
+    const initialThemeValue: ThemeContextType = {
+      theme: 'light',
+      toggleTheme: mockToggleTheme,
+    };
+
+    render(
+      <MemoryRouter>
+        <ThemeContext.Provider value={initialThemeValue}>
+          <Navbar />
+        </ThemeContext.Provider>
+      </MemoryRouter>
+    );
+
+    const toggleButton = screen.getByTestId('theme-toggle-button');
+    fireEvent.click(toggleButton);
+    expect(mockToggleTheme).toHaveBeenCalledTimes(1);
+  });
+
+  test('theme toggle button text updates correctly on click (light to dark)', () => {
+    render(
+      <MemoryRouter>
+        <ThemeProvider> {/* Use actual ThemeProvider to test text change */}
+          <Navbar />
+        </ThemeProvider>
+      </MemoryRouter>
+    );
+
+    const toggleButton = screen.getByTestId('theme-toggle-button');
+    // Initial state (light theme by default if localStorage is empty)
+    expect(toggleButton).toHaveTextContent('Switch to Dark Mode');
+
+    fireEvent.click(toggleButton);
+    // After click (should be dark theme)
+    expect(toggleButton).toHaveTextContent('Switch to Light Mode');
+  });
+
+  test('theme toggle button text updates correctly on click (dark to light)', () => {
+    localStorageMock.setItem('theme', 'dark'); // Start with dark theme
+
+    render(
+      <MemoryRouter>
+        <ThemeProvider> {/* Use actual ThemeProvider to test text change */}
+          <Navbar />
+        </ThemeProvider>
+      </MemoryRouter>
+    );
+
+    const toggleButton = screen.getByTestId('theme-toggle-button');
+    // Initial state (dark theme from localStorage)
+    expect(toggleButton).toHaveTextContent('Switch to Light Mode');
+
+    fireEvent.click(toggleButton);
+    // After click (should be light theme)
+    expect(toggleButton).toHaveTextContent('Switch to Dark Mode');
+  });
+});

--- a/src/Components/NavBar.tsx
+++ b/src/Components/NavBar.tsx
@@ -1,13 +1,22 @@
-import React from "react";
+import React, { useContext } from "react";
 import { NavLink } from "react-router-dom";
+import { ThemeContext } from "../Context/ThemeContext";
 
 function Navbar(props: any) {
+  const themeContext = useContext(ThemeContext);
+
+  if (!themeContext) {
+    return null; // Should not happen with the current ThemeProvider setup
+  }
+
+  const { theme, toggleTheme } = themeContext;
+
   return (
     <div>
       <header
         className="Navbar"
         style={{
-          backgroundColor: "#436895",
+          backgroundColor: "var(--navbar-bg)", // Updated
           position: "fixed",
           top: "0",
           left: "auto",
@@ -18,7 +27,7 @@ function Navbar(props: any) {
           fontFamily: "sans-serif",
           width: "100%",
           zIndex: "1000",
-          boxShadow: "0px 0px 5px #cdadad",
+          boxShadow: "0px 0px 5px #cdadad", // This could also be themed if desired
         }}
         data-testid="header"
       >
@@ -35,14 +44,18 @@ function Navbar(props: any) {
           <div
             className="Title"
             data-testid="navbarAppName"
-            style={{ flexGrow: "1" ,color: "#f3f9ff"}}
+            style={{ flexGrow: "1", color: "var(--navbar-text)" }} // Updated
           >
             Cricket Match App{" "}
           </div>
           <div>
             <NavLink to="/match">
               <button
-                style={{ marginRight: "10px" }}
+                style={{
+                  marginRight: "10px",
+                  backgroundColor: "var(--button-bg)", // Updated
+                  color: "var(--button-text)", // Updated
+                }}
                 data-testid="matchbuttononnavbar"
               >
                 {" "}
@@ -51,7 +64,11 @@ function Navbar(props: any) {
             </NavLink>
             <NavLink to="/player">
               <button
-                style={{ marginRight: "10px" }}
+                style={{
+                  marginRight: "10px",
+                  backgroundColor: "var(--button-bg)", // Updated
+                  color: "var(--button-text)", // Updated
+                }}
                 data-testid="playerbuttononnavbar"
               >
                 {" "}
@@ -60,13 +77,28 @@ function Navbar(props: any) {
             </NavLink>
             <NavLink to="/login">
               <button
-                style={{ marginRight: "10px" }}
+                style={{
+                  marginRight: "10px",
+                  backgroundColor: "var(--button-bg)", // Updated
+                  color: "var(--button-text)", // Updated
+                }}
                 data-testid="loginbuttononnavbar"
               >
                 {" "}
                 Login{" "}
               </button>
             </NavLink>
+            <button
+              onClick={toggleTheme}
+              style={{
+                marginRight: "10px",
+                backgroundColor: "var(--button-bg)",
+                color: "var(--button-text)",
+              }}
+              data-testid="theme-toggle-button"
+            >
+              {theme === "light" ? "Switch to Dark Mode" : "Switch to Light Mode"}
+            </button>
           </div>
         </div>
       </header>

--- a/src/Components/Player.tsx
+++ b/src/Components/Player.tsx
@@ -60,6 +60,7 @@ function Player(): JSX.Element {
             width: "100%",
             justifyContent: "center",
             display: "flex",
+            color: "var(--text-color)", // Explicitly set text color
           }}
         >
           Players List

--- a/src/Components/Player.tsx
+++ b/src/Components/Player.tsx
@@ -103,7 +103,7 @@ function Player(): JSX.Element {
                           sx={{ maxWidth: 255 }}
                           style={{
                             marginTop: "10",
-                            backgroundColor: "rgb(195 186 169)",
+                            backgroundColor: "var(--card-bg-alt)", // Updated
                             width: "400px",
                           }}
                           data-testid="card-id"
@@ -153,8 +153,12 @@ function Player(): JSX.Element {
             style={{
               marginTop: "60px",
               marginLeft: "45%",
-              color: "#9d7506",
+              color: "var(--button-text)", // Updated
+              backgroundColor: "var(--button-bg)", // Updated
+              border: "1px solid var(--button-border-color)", // Added for consistency
               width: "120px",
+              padding: "8px 16px", // Added for better appearance
+              borderRadius: "4px", // Added for better appearance
             }}
           >
             Add Player

--- a/src/Components/Register.tsx
+++ b/src/Components/Register.tsx
@@ -54,17 +54,18 @@ function Register(): JSX.Element {
     <>
       <div style={{ justifyContent: "center" }}>
         <nav
-          className="bg-dark navbar-dark navbar"
+          className="bg-dark navbar-dark navbar" // These classes are now themed by src/theme.css
           style={{ marginTop: "200px", justifyContent: "center" }}
         >
-          <div className="row col-12 d-flex justify-content-center text-white">
+          <div className="row col-12 d-flex justify-content-center text-white"> {/* text-white is themed */}
             <h3 data-testid="registration">Registration</h3>
           </div>
         </nav>
         <div
-          className="form"
+          className="form" // We can add a class like 'themed-card' if we define it in theme.css
           style={{
-            backgroundColor: "rgb(205 205 205)",
+            backgroundColor: "var(--card-bg-alt)", // Use CSS variable for the alternate card background
+            boxShadow: "var(--card-box-shadow)", // Use CSS variable
             borderRadius: "5px",
             width: "550px",
             margin: "20px auto",
@@ -77,29 +78,29 @@ function Register(): JSX.Element {
           >
             <div className="username">
               <label
-                className="form__label"
+                className="form__label" // Style this class globally or ensure text color is inherited
                 htmlFor="firstName"
                 data-testid="firstnamelabel"
-                style={{ width: "40%", padding: "5px" }}
+                style={{ width: "40%", padding: "5px", color: "var(--text-color)" }} // Added text color
               >
                 First Name
               </label>
               <input
-                className="form__input"
+                className="form__input" // This class is styled in theme.css
                 type="text"
                 id="firstName"
                 placeholder="First Name"
                 onChange={(e) => {
                   setUserName(e.target.value);
                 }}
-                style={{ width: "60%" }}
+                style={{ width: "60%" }} // Layout style, can remain
               />
             </div>
             <div className="email">
               <label
-                className="form__label"
+                className="form__label" // Style this class globally or ensure text color is inherited
                 htmlFor="email"
-                style={{ width: "40%", padding: "5px" }}
+                style={{ width: "40%", padding: "5px", color: "var(--text-color)" }} // Added text color
                 data-testid="emaillabel"
               >
                 Email
@@ -107,32 +108,32 @@ function Register(): JSX.Element {
               <input
                 type="email"
                 id="email"
-                className="form__input"
+                className="form__input" // This class is styled in theme.css
                 placeholder="Email"
                 onChange={(e) => {
                   setEmail(e.target.value);
                 }}
-                style={{ width: "60%" }}
+                style={{ width: "60%" }} // Layout style, can remain
               />
             </div>
             <div className="password">
               <label
-                className="form__label"
+                className="form__label" // Style this class globally or ensure text color is inherited
                 htmlFor="password"
-                style={{ width: "40%", padding: "5px" }}
+                style={{ width: "40%", padding: "5px", color: "var(--text-color)" }} // Added text color
                 data-testid="passwordlabel"
               >
                 Password
               </label>
               <input
-                className="form_input"
+                className="form__input" // Corrected typo from form_input and styled in theme.css
                 type="password"
                 id="password"
                 placeholder="Password"
                 onChange={(e) => {
                   setPassword(e.target.value);
                 }}
-                style={{ width: "60%" }}
+                style={{ width: "60%" }} // Layout style, can remain
               />
             </div>
           </div>

--- a/src/Context/ThemeContext.test.tsx
+++ b/src/Context/ThemeContext.test.tsx
@@ -1,0 +1,126 @@
+import React, { useContext } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, ThemeContext } from './ThemeContext';
+
+// LocalStorage Mock
+const localStorageMock = (() => {
+  let store: { [key: string]: string } = {};
+  return {
+    getItem: jest.fn(key => store[key] || null),
+    setItem: jest.fn((key, value) => {
+      store[key] = value.toString();
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+    removeItem: jest.fn(key => {
+      delete store[key];
+    }),
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+// Helper component to display context values
+const TestConsumerComponent = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    return <div>No context</div>;
+  }
+  return (
+    <div>
+      <div data-testid="theme-value">{context.theme}</div>
+      <button onClick={context.toggleTheme}>Toggle Theme</button>
+    </div>
+  );
+};
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    localStorageMock.setItem.mockClear();
+    localStorageMock.getItem.mockClear();
+    document.body.classList.remove('dark-theme'); // Reset body class
+  });
+
+  test('provides initial theme as "light" by default', () => {
+    render(
+      <ThemeProvider>
+        <TestConsumerComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+  });
+
+  test('provides initial theme from localStorage if set to "dark"', () => {
+    localStorageMock.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestConsumerComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('dark');
+    // Check if document.body has 'dark-theme' class due to initial load effect
+    expect(document.body).toHaveClass('dark-theme');
+  });
+
+  test('provides initial theme from localStorage if set to "light"', () => {
+    localStorageMock.setItem('theme', 'light');
+    render(
+      <ThemeProvider>
+        <TestConsumerComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+    expect(document.body).not.toHaveClass('dark-theme');
+  });
+
+  test('toggleTheme switches theme from light to dark and updates localStorage', () => {
+    render(
+      <ThemeProvider>
+        <TestConsumerComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+    fireEvent.click(screen.getByText('Toggle Theme'));
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('dark');
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('theme', 'dark');
+  });
+
+  test('toggleTheme switches theme from dark to light and updates localStorage', () => {
+    localStorageMock.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestConsumerComponent />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('dark');
+    fireEvent.click(screen.getByText('Toggle Theme'));
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('theme', 'light');
+  });
+
+  test('toggleTheme adds "dark-theme" class to document.body when switching to dark', () => {
+    render(
+      <ThemeProvider>
+        <TestConsumerComponent />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByText('Toggle Theme')); // light -> dark
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('dark');
+    expect(document.body).toHaveClass('dark-theme');
+  });
+
+  test('toggleTheme removes "dark-theme" class from document.body when switching to light', () => {
+    localStorageMock.setItem('theme', 'dark');
+    render(
+      <ThemeProvider>
+        <TestConsumerComponent />
+      </ThemeProvider>
+    );
+    expect(document.body).toHaveClass('dark-theme'); // Initial state
+    fireEvent.click(screen.getByText('Toggle Theme')); // dark -> light
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+    expect(document.body).not.toHaveClass('dark-theme');
+  });
+});

--- a/src/Context/ThemeContext.tsx
+++ b/src/Context/ThemeContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useState, useEffect, ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+// Create the context with a default value
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      return storedTheme;
+    }
+    return 'light'; // Default theme
+  });
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => {
+      const newTheme = prevTheme === 'light' ? 'dark' : 'light';
+      localStorage.setItem('theme', newTheme);
+      return newTheme;
+    });
+  };
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.body.classList.add('dark-theme');
+    } else {
+      document.body.classList.remove('dark-theme');
+    }
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider } from './Context/ThemeContext';
+import './theme.css';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-  
+    <ThemeProvider>
       <App />
-
+    </ThemeProvider>
   </React.StrictMode>
 );
 // AddMatch(toast);

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,140 @@
+:root {
+  --body-bg: #fbfbfb;
+  --text-color: #000000;
+  --text-color-rgb: 0,0,0; /* New RGB variable */
+  --navbar-bg: #436895;
+  --navbar-text: #f3f9ff;
+  --button-bg: #e0e0e0;
+  --button-text: #000000;
+  --button-border-color: var(--button-bg);
+  --button-hover-bg: #d0d0d0; /* New hover variable */
+  --link-color: #007bff;
+  --link-color-rgb: 0,123,255; /* New RGB variable */
+
+  /* New variables for forms/cards */
+  --card-bg: #ffffff;
+  --card-bg-alt: #cdcdcd; /* For Register form's slightly different bg */
+  --card-box-shadow: 0px 0px 10px rgba(0,0,0,0.1);
+  --input-bg: #ffffff;
+  --input-border-color: #ced4da;
+  --input-text-color: #495057;
+  --placeholder-text-color: #6c757d;
+
+  /* Toast variables */
+  --toast-bg: #ffffff;
+  --toast-text-color: #333333;
+  --toast-success-bg: #e6fffa;
+  --toast-success-text-color: #004d40;
+  --toast-error-bg: #ffebee;
+  --toast-error-text-color: #c62828;
+}
+
+.dark-theme {
+  --body-bg: #121212;
+  --text-color: #ffffff;
+  --text-color-rgb: 255,255,255; /* New RGB variable - Dark */
+  --navbar-bg: #1e1e1e;
+  --navbar-text: #ffffff;
+  --button-bg: #555555; /* Darker button for better contrast on dark bg */
+  --button-text: #ffffff;
+  --button-border-color: var(--button-bg);
+  --button-hover-bg: #454545; /* New hover variable - Dark */
+  --link-color: #bb86fc;
+  --link-color-rgb: 187,134,252; /* New RGB variable - Dark */
+
+  /* New variables for forms/cards - Dark */
+  --card-bg: #2c2c2c;
+  --card-bg-alt: #3a3a3a;
+  --card-box-shadow: 0px 0px 10px rgba(255,255,255,0.05);
+  --input-bg: #3a3a3a;
+  --input-border-color: #555555;
+  --input-text-color: #e0e0e0;
+  --placeholder-text-color: #888888;
+
+  /* Toast variables - Dark */
+  --toast-bg: var(--card-bg); /* Align with card background */
+  --toast-text-color: var(--text-color); /* Align with general text color */
+  --toast-success-bg: #1a3c32; 
+  --toast-success-text-color: #a7f3d0;
+  --toast-error-bg: #4c1c1c;
+  --toast-error-text-color: #fecaca;
+}
+
+body {
+  background-color: var(--body-bg);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Bootstrap Overrides for Dark Theme */
+.dark-theme .form-control, /* Standard Bootstrap input */
+.dark-theme .form__input,  /* Custom class from Login/Register */
+.dark-theme .form_input   /* Custom class typo from Register */ {
+  background-color: var(--input-bg);
+  color: var(--input-text-color);
+  border: 1px solid var(--input-border-color);
+}
+
+.dark-theme .form-control::placeholder,
+.dark-theme .form__input::placeholder,
+.dark-theme .form_input::placeholder {
+  color: var(--placeholder-text-color);
+}
+
+/* General button styling (assuming .btn is used) */
+.dark-theme .btn {
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border-color: var(--button-border-color);
+}
+
+/* Specific Bootstrap class overrides if needed */
+.dark-theme .bg-dark {
+  background-color: var(--navbar-bg) !important; /* Override Bootstrap's !important if necessary */
+}
+
+.dark-theme .text-white {
+  color: var(--navbar-text) !important; /* Override Bootstrap's !important if necessary */
+}
+
+/* Styling for the form containers if they were generic .card */
+.dark-theme .card { /* If Login/Register forms were using .card class */
+  background-color: var(--card-bg);
+  border-color: var(--input-border-color); /* Or a specific card border color */
+}
+
+/* React Toastify Dark Theme Overrides */
+.dark-theme .Toastify__toast-container .Toastify__toast {
+  background-color: var(--toast-bg);
+  color: var(--toast-text-color);
+  box-shadow: var(--card-box-shadow); /* Use card shadow for consistency */
+}
+
+.dark-theme .Toastify__toast-container .Toastify__toast--success {
+  background-color: var(--toast-success-bg);
+  color: var(--toast-success-text-color);
+}
+
+.dark-theme .Toastify__toast-container .Toastify__toast--error {
+  background-color: var(--toast-error-bg);
+  color: var(--toast-error-text-color);
+}
+
+.dark-theme .Toastify__toast-container .Toastify__close-button {
+  color: var(--toast-text-color);
+  opacity: 0.7; /* Default is 0.3, make it more visible */
+}
+.dark-theme .Toastify__toast-container .Toastify__close-button:hover {
+  opacity: 1;
+}
+
+/* Optional: Style progress bar if needed */
+.dark-theme .Toastify__progress-bar {
+  background: var(--link-color); /* Use link color for progress bar */
+}
+.dark-theme .Toastify__progress-bar--success {
+  background: var(--toast-success-text-color); /* Or a specific success progress color */
+}
+.dark-theme .Toastify__progress-bar--error {
+  background: var(--toast-error-text-color); /* Or a specific error progress color */
+}


### PR DESCRIPTION
This commit introduces a dark theme option to the application.

Key changes include:
-   Created a ThemeContext and ThemeProvider to manage theme state ('light'/'dark') and persist your preference in localStorage.
-   Defined CSS variables for light and dark themes in a global `theme.css` file. The ThemeProvider dynamically applies a 'dark-theme' class to the body.
-   Added a theme toggle button to the NavBar, allowing you to switch between themes.
-   Refactored existing components (Login, Register, Match, Player, AddMatch, AddPlayer, DeleteDialog, NavBar) to use theme-aware styles (CSS variables and Material UI `sx` props).
-   Styled `react-toastify` notifications to be consistent with the selected theme.
-   Added unit and integration tests for the theme context, provider, and NavBar toggle functionality, ensuring the core theme switching mechanism is robust.

The implementation primarily targets core application components and lays a foundation for further theme enhancements if needed.